### PR TITLE
feat: use jsonpatch to generate a concise patch

### DIFF
--- a/image_replacer_webhook/server.py
+++ b/image_replacer_webhook/server.py
@@ -6,8 +6,8 @@ import copy
 import base64
 import json
 import logging
-import jsonpatch
 from typing import Optional
+import jsonpatch
 from fastapi import Body, FastAPI
 from pydantic import BaseModel
 from image_replacer_webhook.setting import settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 pydantic-settings
 httpx
+jsonpatch

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,5 +32,5 @@ def test_mutate_post(client):
     )
     for p in patch:
         assert p["op"] == "replace"
-        assert re.match(r"(/spec/(initContainers|containers)/(\d+)/image)", p["path"])
+        assert re.match(r"(/spec/(initContainers|containers)/(\d+)/image)", p["path"]) is not None
         assert p["value"].startswith("m.daocloud.io/docker.io/")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 Author: NierYYDS
 """
 
+import re
 import json
 import base64
 import pytest
@@ -31,6 +32,5 @@ def test_mutate_post(client):
     )
     for p in patch:
         assert p["op"] == "replace"
-        assert p["path"] in ["/spec/containers", "/spec/initContainers"]
-        for c in p["value"]:
-            assert c["image"].startswith("m.daocloud.io/docker.io/")
+        assert re.match(r"(/spec/(initContainers|containers)/(\d+)/image)", p["path"])
+        assert p["value"].startswith("m.daocloud.io/docker.io/")


### PR DESCRIPTION
the patch before will send back all spec info of pod‘s containers, but we only change the image, so this PR will build patch which only return replacement of image.